### PR TITLE
Fix acquiring the InvocationID

### DIFF
--- a/usr/local/bin/systemd-telegram
+++ b/usr/local/bin/systemd-telegram
@@ -63,14 +63,8 @@ read_unit_property() {
 
 # arguments:
 #   unitname
-read_unit_invocation_id() {
-  journalctl -u "$1" -n "1" --output-fields "INVOCATION_ID" -o "cat"
-}
-
-# arguments:
-#   unitname
 read_unit_journal() {
-  invocation_id="$(read_unit_invocation_id "$1")"
+  invocation_id="$(read_unit_property "$1" "InvocationID")"
   journalctl -u "$1" -n "10000" _SYSTEMD_INVOCATION_ID="${invocation_id}"
 }
 


### PR DESCRIPTION
On `systemd 241` the `read_unit_invocation_id()` function fails to provide an `InvocationID`, it only provides the last log line from the journal:

```
# journalctl -u "borgmatic" -n "1" --output-fields "INVOCATION_ID" -o "cat"
borgmatic.service: Triggering OnFailure= dependencies.
```

The `read_unit_property()` function works just fine:

```
# systemctl show "borgmatic" --value -p "InvocationID"
d615425ee8c641d79bf74c1c95a8f8b8
```

Without this fix the attachment in the Telegram message has an empty log. With it, I get the full log for the failed service start.

Thanks for this approach by the way, it works awesome and is a life saver :)