### PR TITLE
Add support for --user units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 !/usr/local/bin/systemd-telegram
 !/usr/local/etc/systemd-telegram/*.env
 !/etc/systemd/system/*.service
+!/etc/systemd/user/*.service

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,19 @@
 SRC_BIN     = $(wildcard usr/local/bin/*)
 SRC_ETC     = $(wildcard usr/local/etc/systemd-telegram/*)
 SRC_SYSTEMD = $(wildcard etc/systemd/system/*)
+SRC_SYSTEMD_USER = $(wildcard etc/systemd/user/*)
 
 DST_BIN     = /usr/local/bin
 DST_ETC     = /usr/local/etc/systemd-telegram
 DST_SYSTEMD = /etc/systemd/system
+DST_SYSTEMD_USER = /etc/systemd/user
 
 BACKUP      = existing
 INSTALL     = install --backup=$(BACKUP)
 
 install: update install-config 
 
-update: install-script install-systemd
+update: install-script install-systemd install-systemd-user
 
 install-script:
 	$(INSTALL) -d $(DST_BIN)
@@ -26,3 +28,7 @@ install-config:
 install-systemd: 
 	$(INSTALL) -d $(DST_SYSTEMD)
 	$(INSTALL) -m 0644 -t $(DST_SYSTEMD) $(SRC_SYSTEMD)
+
+install-systemd-user: 
+	$(INSTALL) -d $(DST_SYSTEMD_USER)
+	$(INSTALL) -m 0644 -t $(DST_SYSTEMD_USER) $(SRC_SYSTEMD_USER)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ personal `chat_id`. To create both, please see the documentation of the
 Once obtained, both secrets need to be configured in
 `/usr/local/etc/systemd-telegram/telegram.env`.
 
+### Using `--user` units
+
+To send notifications with `--user` units, you need to add the above bot secrets (or a new pair) to `~/.config/systemd-telegram/telegram.env`.
+
 ### Send notifications on failure
 
 To send a notification on failure (including the journal logs), you must create

--- a/etc/systemd/user/systemd-telegram@.service
+++ b/etc/systemd/user/systemd-telegram@.service
@@ -6,6 +6,5 @@ After=network.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=/usr/local/etc/systemd-telegram/telegram.env
+EnvironmentFile=%h/.config/systemd-telegram/telegram.env
 ExecStart=/usr/local/bin/systemd-telegram "%i" "%U"
-Group=systemd-journal

--- a/usr/local/bin/systemd-telegram
+++ b/usr/local/bin/systemd-telegram
@@ -55,24 +55,32 @@ send_message() {
 }
 
 # arguments:
+#   manager
 #   unitname
 #   propertyname
 read_unit_property() {
-  systemctl show "$1" --value -p "$2"
+  systemctl show "$1" "$2" --value -p "$3"
 }
 
 # arguments:
+#   manager
 #   unitname
 read_unit_journal() {
-  invocation_id="$(read_unit_property "$1" "InvocationID")"
-  journalctl -u "$1" -n "10000" _SYSTEMD_INVOCATION_ID="${invocation_id}"
+  invocation_id="$(read_unit_property "$1" "$2" "InvocationID")"
+  journalctl "$1" -u "$2" -n "10000" _SYSTEMD_INVOCATION_ID="${invocation_id}"
 }
 
 # arguments:
 #   unitname - systemd unit name.
+#   uid - numeric uid of user running the service manager instance
 main() {
-  active_state="$(read_unit_property "$1" "ActiveState")"
-  description="$(read_unit_property "$1" "Description")"
+  if [[ "${2:-0}" == "0" ]]; then
+    manager="--system"
+  else
+    manager="--user"
+  fi
+  active_state="$(read_unit_property "$manager" "$1" "ActiveState")"
+  description="$(read_unit_property "$manager" "$1" "Description")"
   message="${description} completed.
 
 Hostname=${HOSTNAME}
@@ -82,7 +90,7 @@ ActiveState=${active_state}"
   if [[ "${active_state}" == "failed" ]]; then
     log "Unit $1 failed. Sending notification with journal."
     filename="$1.$(date "+%Y-%m-%dT%H:%M:%S%z").txt"
-    read_unit_journal "$1" | send_document "${message}" "${filename}"
+    read_unit_journal "${manager}" "$1" | send_document "${message}" "${filename}"
   else
     log "Unit has state ${active_state}. Sending simple notification"
     send_message "${message}"


### PR DESCRIPTION
Allows to do the following:

`systemctl --user start systemd-telegram@user-service.service`

I modified the service file to pass a second argument (`%U`) to the executable. The executable use this argument to know if it should pass either `--system` (default) or `--user` to `journalctl` or `systemctl`.

> Systemd unit specifier:
> "%U" | User UID | This is the numeric UID of the user running the service manager       instance. In case of the system manager this resolves to       "0". Note that this setting is not influenced by the       User= setting configurable in the [Service] section of the service       unit.
> -- | -- | --

