### PR TITLE
Send silent messages on success

### DIFF
--- a/usr/local/bin/systemd-telegram
+++ b/usr/local/bin/systemd-telegram
@@ -34,6 +34,7 @@ send_document() {
     --fail \
     --form "chat_id=${TELEGRAM_CHAT_ID}" \
     --form "caption=$1" \
+    --form "disable_notification=$3" \
     --form "document=@-;filename=$2" \
     "$(telegram_endpoint "sendDocument")"
 }
@@ -51,6 +52,7 @@ send_message() {
     --fail \
     --form "chat_id=${TELEGRAM_CHAT_ID}" \
     --form "text=$1" \
+    --form "disable_notification=$2" \
     "$(telegram_endpoint "sendMessage")"
 }
 
@@ -85,10 +87,10 @@ ActiveState=${active_state}"
   if [[ "${active_state}" == "failed" ]]; then
     log "Unit $2 failed. Sending notification with journal."
     filename="$2.$(date "+%Y-%m-%dT%H-%M-%S%z").txt"
-    read_unit_journal "$1" "$2" | send_document "${message}" "${filename}"
+    read_unit_journal "$1" "$2" | send_document "${message}" "${filename}" false
   else
     log "Unit $2 has state ${active_state}. Sending simple notification"
-    send_message "${message}"
+    send_message "${message}" true
   fi
 }
 


### PR DESCRIPTION
It seems to me that success notifications mostly serve as a confirmation that the service didn't silently die (e.g. that daily backup job runs). Imo this doesn't require a loud notification (in contrary to failure message), it's enough that you'll see the messages when you open telegram.